### PR TITLE
Fix/post processing

### DIFF
--- a/irdpackage/CHECKLOG.md
+++ b/irdpackage/CHECKLOG.md
@@ -35,6 +35,8 @@ One difference appears in the post-processing step for integer-valued features. 
 
 This adjustment to the post-processing logic was reviewed and approved by Prof. Giuseppe.
 
+Note: rebuilding ParamSet objects rather than mutating them in place was necessary for the migration to paradox = 1.0.1. Routines that update boxes frequently (like PRIM and PostProcessing) now have more overhead as a result.
+
 #### Dependencies (current CRAN versions)
 
 * `mlr3` = 1.5.0

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -217,8 +217,8 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
     },
     evaluate_box = function(box, desired_range, x_interest) {
       private$.calls_fhat = private$.calls_fhat + private$evaluation_n
-      evaluate_box(box, predictor = private$predictor, x_interest = x_interest,
-        n_samples = private$evaluation_n, desired_range)
+      evaluate_box(box = box, predictor = private$predictor, x_interest = x_interest,
+        n_samples = private$evaluation_n, desired_range = desired_range)
     },
     peeling_subbox = function(box_new) {
       a = lapply(sample(names(private$searchspace)), FUN = function(j) { #<FIXME:> mclapply

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -29,7 +29,7 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
                           quiet = FALSE) {
       # input checks
       super$initialize(predictor, quiet)
-      checkmate::assert_numeric(subbox_relsize, lower = 0, upper = 1)
+      checkmate::qassert(subbox_relsize, "N?(0,1]")
       checkmate::assert_integerish(evaluation_n, lower = 0)
       checkmate::assert_numeric(paste_alpha, len = 1L)
       checkmate::assert_names(strategy_ties, subset.of = c("preddist", "random"))

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -31,7 +31,7 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
       super$initialize(predictor, quiet)
       checkmate::qassert(subbox_relsize, "N?(0,1]")
       checkmate::assert_integerish(evaluation_n, lower = 0)
-      checkmate::assert_numeric(paste_alpha, len = 1L)
+      checkmate::qassert(paste_alpha, "N?(0,1)")
       checkmate::assert_choice(strategy_ties, choices = c("preddist", "random"))
       # assign private attr
       private$subbox_relsize = subbox_relsize

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -32,7 +32,7 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
       checkmate::qassert(subbox_relsize, "N?(0,1]")
       checkmate::assert_integerish(evaluation_n, lower = 0)
       checkmate::assert_numeric(paste_alpha, len = 1L)
-      checkmate::assert_names(strategy_ties, subset.of = c("preddist", "random"))
+      checkmate::assert_choice(strategy_ties, choices = c("preddist", "random"))
       # assign private attr
       private$subbox_relsize = subbox_relsize
       private$evaluation_n = evaluation_n

--- a/irdpackage/R/RegDescMethod.R
+++ b/irdpackage/R/RegDescMethod.R
@@ -101,6 +101,7 @@ RegDescMethod = R6::R6Class("RegDescMethod",
 
       # Set number of calls to fhat to 0
       private$.calls_fhat = 0
+      private$.history = NULL
 
       private$x_interest = x_interest
       private$f_hat_interest = f_hat_interest

--- a/irdpackage/R/RegDescMethod.R
+++ b/irdpackage/R/RegDescMethod.R
@@ -83,7 +83,7 @@ RegDescMethod = R6::R6Class("RegDescMethod",
         assert_set_equal(box_init$ids(), private$predictor$data$feature.names)
         # <FIXME:> Take update fixed_features into account!
 
-        if (!box_contains_x_interest(box_init, x_interest)) {
+        if (!all(identify_in_box(box_init, x_interest))) {
           stop("`box_init` must contain `x_interest`.", call. = FALSE)
         }
       }

--- a/irdpackage/R/RegDescMethod.R
+++ b/irdpackage/R/RegDescMethod.R
@@ -82,6 +82,10 @@ RegDescMethod = R6::R6Class("RegDescMethod",
       if (!is.null(box_init)) {
         assert_set_equal(box_init$ids(), private$predictor$data$feature.names)
         # <FIXME:> Take update fixed_features into account!
+
+        if (!box_contains_x_interest(box_init, x_interest)) {
+          stop("`box_init` must contain `x_interest`.", call. = FALSE)
+        }
       }
 
       # Check box_largest

--- a/irdpackage/R/helpers.R
+++ b/irdpackage/R/helpers.R
@@ -516,18 +516,19 @@ get_max_box = function (x_interest, fixed_features, predictor, param_set, desire
 
 identify_in_box = function(box, data) {
   ids = box$ids()  # feature names
-  data = data.table::setDT(data)
-  data = data[, ids, with = FALSE]
-  check_inbox = function(col, param_id) {
-    dom = box$get_domain(param_id)  # domain used to identify data type
-    if (paradox::domain_is_number(dom)) {
-      col >= box$lower[[param_id]] & col <= box$upper[[param_id]]
-    } else if (paradox::domain_is_categ(dom)) {
-      col %in% box$levels[[param_id]]
+  data = data.table::setDT(data)[, ids, with = FALSE]
+  cls = box$class[ids]
+  checks = lapply(ids, function(j) {
+    if (cls[[j]] %in% c("ParamInt", "ParamDbl")) {
+      data[[j]] >= box$lower[[j]] & data[[j]] <= box$upper[[j]]
+    } else if (cls[[j]] == "ParamFct") {
+      data[[j]] %in% box$levels[[j]]
+    } else {
+      stop(sprintf("Unsupported parameter class for '%s': %s", j, cls[[j]]))
     }
-  }
-  datainbox = data[, Map(check_inbox, .SD, names(.SD)), .SDcols = ids]
-  apply(datainbox, 1, all)
+  })
+
+  Reduce(`&`, checks)
 }
 
 # surpress messages

--- a/irdpackage/R/helpers.R
+++ b/irdpackage/R/helpers.R
@@ -557,3 +557,15 @@ sampling = function(predictor, x_interest, fixed_features, desired_range, param_
   }
   return(sampdata)
 }
+
+box_contains_x_interest = function(box, x_interest) {
+  ids = box$ids()
+  all(mapply(function(j, cls) {
+    value = x_interest[[j]]
+    switch(cls,
+           "ParamDbl" = box$lower[[j]] <= value && value <= box$upper[[j]],
+           "ParamInt" = box$lower[[j]] <= value && value <= box$upper[[j]],
+           "ParamFct" = value %in% box$levels[[j]]
+    )
+  }, ids, box$class[ids]))
+}

--- a/irdpackage/R/helpers.R
+++ b/irdpackage/R/helpers.R
@@ -559,14 +559,3 @@ sampling = function(predictor, x_interest, fixed_features, desired_range, param_
   return(sampdata)
 }
 
-box_contains_x_interest = function(box, x_interest) {
-  ids = box$ids()
-  all(mapply(function(j, cls) {
-    value = x_interest[[j]]
-    switch(cls,
-           "ParamDbl" = box$lower[[j]] <= value && value <= box$upper[[j]],
-           "ParamInt" = box$lower[[j]] <= value && value <= box$upper[[j]],
-           "ParamFct" = value %in% box$levels[[j]]
-    )
-  }, ids, box$class[ids]))
-}


### PR DESCRIPTION
This PR improves validation and peformance in PostProcessing

- The method history is reset at the beginning of find_box() to avoid accumulation across calls
- Tighter validation of the algorithm parameters:
   - The parameter subbox_relsize is now required to be in (0,1]
   - The parameter paste_alpha is required to be in (0, 1)
   - The parameter strategy_ties is now validated by the function assert_choice()
- A validation check is now performed to ensure that box_init contains x_interest when using PostProcessing
- The function identify_in_box() is optimized by avoiding the call to paradox.get_domain() and instead using the parameter class from the object ParamSet

Note: the overhead of recreating the object ParamSet in the function update_box() still persists, but it's inevitable since ParamSet is no longer mutable.

> The ParamSet should be considered immutable, except for some fields such as $values , $deps , $tags. Bounds and levels should not be changed after construction. Instead, a new ParamSet should be constructed.