### PR TITLE
Fix validation, documentation and minor bugs in RegDesc

### DIFF
--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -165,7 +165,7 @@ RegDesc = R6::R6Class("RegDesc",
       if (missing(value)) {
         private$.box_single
       } else {
-        stop("`$box` is read only", call. = FALSE)
+        stop("`$box_single` is read only", call. = FALSE)
       }
     },
     #' @field x_interest (`data.table(1)`) \cr

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -42,6 +42,7 @@ RegDesc = R6::R6Class("RegDesc",
       private$.x_interest = x_interest
       private$.desired_range = desired_range
       private$.desired_class = desired_class
+      private$.fixed_features = fixed_features
       private$.method = method
       if (predictor$task == "unknown") {
         if (is.numeric(predictor$data$y[[1]])) {

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -63,7 +63,7 @@ RegDesc = R6::R6Class("RegDesc",
     #' @param digits (`integer(1)`) Number of decimal places used when printing numeric box boundaries.
     print = function(digits = 2L) {
       desired = private$.desired_range
-      cat(nrow(private$.data), "Regional Descriptors \n \n")
+      cat("Regional Descriptors \n \n")
       if (private$predictor$task == "classification") {
         cat("Desired class:", private$predictor$class, "\n")
       }

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -32,7 +32,7 @@ RegDesc = R6::R6Class("RegDesc",
       assert_numeric(desired_range, len = 2L)
       assert_character(desired_class, null.ok = TRUE)
       if (!is.null(fixed_features)) {
-        assert_names(fixed_features, subset.of = predictor$data$features.names)
+        assert_names(fixed_features, subset.of = predictor$data$feature.names)
       }
       assert_character(method, len = 1L)
       assert_names(box$ids(), permutation.of = predictor$data$feature.names)

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -9,14 +9,13 @@ RegDesc = R6::R6Class("RegDesc",
     #'   The object (created with `iml::Predictor$new()`) holding the machine learning model and the data.
     #' @param desired_range (`numeric(2)`) \cr
     #'   Desired predicted outcome interval associated with the descriptor.
-    #'   This must be a length-2 numeric vector already resolved by the calling
-    #'   `$find_box()` method.
+    #'   This must be a length-2 numeric vector already resolved by the calling `$find_box()` method.
     #'   This outcome interval needs to include the predicted value of `x_interest`.
     #' @param fixed_features (`character()` | NULL)
     #'   Names of features that are kept fixed (immutable) when constructing the descriptor.
     #' @param desired_class (`character(1)` | NULL)
     #'   Desired class for classification models. NULL for regression.
-    #' @param method (`character(1)` | NULL)
+    #' @param method (`character(1)`)
     #'   Name of the method used to generate the regional descriptor.
     initialize = function(box,
                           predictor,
@@ -35,7 +34,7 @@ RegDesc = R6::R6Class("RegDesc",
       if (!is.null(fixed_features)) {
         assert_names(fixed_features, subset.of = predictor$data$features.names)
       }
-      assert_character(method)
+      assert_character(method, len = 1L)
       assert_names(box$ids(), permutation.of = predictor$data$feature.names)
 
       # assign

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -150,7 +150,7 @@ RegDesc = R6::R6Class("RegDesc",
         stop("`$desired_range` is read only", call. = FALSE)
       }
     },
-    #' @field box (`data.table`)\cr
+    #' @field box (`ParamSet`)\cr
     #'  The regional descriptor for `x_interest`.
     box = function(value) {
       if (missing(value)) {
@@ -159,7 +159,7 @@ RegDesc = R6::R6Class("RegDesc",
         stop("`$box` is read only", call. = FALSE)
       }
     },
-    #' @field box_single (`data.table`)\cr
+    #' @field box_single (`ParamSet`)\cr
     #'  The regional descriptors only mutating a single feature for `x_interest`.
     box_single = function(value) {
       if (missing(value)) {

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -102,7 +102,7 @@ RegDesc = R6::R6Class("RegDesc",
     #' @param surface (`character(1)`) Which surface to plot: `"prediction"` or `"range"`.
     #' @return A `ggplot2` object.
     plot_surface = function(feature_names, grid_size = 250L, surface = "prediction") {
-      assert_names(surface, subset.of = c("prediction", "range"))
+      assert_choice(surface, choices = c("prediction", "range"))
       assert_names(feature_names, subset.of = private$.box$ids())
       if (!requireNamespace("ggplot2", quietly = TRUE)) {
         stop("Package 'ggplot2' needed for this function to work. Please install it.", call. = FALSE)

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -7,9 +7,11 @@ RegDesc = R6::R6Class("RegDesc",
     #'   A single row with the observation of interest.
     #' @param predictor (\link[iml]{Predictor})\cr
     #'   The object (created with `iml::Predictor$new()`) holding the machine learning model and the data.
-    #' @param desired_range (NULL | `numeric(2)`) \cr
-    #' The desired predicted outcome. If NULL (default), the current predicted value of `predictor` for `x_interest` is used as desired prediction.
-    #' Alternatively, a vector with two numeric values that specify an outcome interval. This outcome interval needs to include the predicted value of `x_interest`.
+    #' @param desired_range (`numeric(2)`) \cr
+    #'   Desired predicted outcome interval associated with the descriptor.
+    #'   This must be a length-2 numeric vector already resolved by the calling
+    #'   `$find_box()` method.
+    #'   This outcome interval needs to include the predicted value of `x_interest`.
     #' @param fixed_features (`character()` | NULL)
     #'   Names of features that are kept fixed (immutable) when constructing the descriptor.
     #' @param desired_class (`character(1)` | NULL)

--- a/irdpackage/R/RegDesc.R
+++ b/irdpackage/R/RegDesc.R
@@ -1,7 +1,7 @@
 RegDesc = R6::R6Class("RegDesc",
   public = list(
     #' Creates a new Regional Descriptor (`RegDesc`) object.
-    #' This method should only be called by the `$find_box` methods of \link{Prim}.
+    #' This method should only be called by the `$find_box` methods of regional descriptor algorithms, such as \link{Prim}, \link{MaxBox}, \link{Maire} or \link{PostProcessing}.
     #' @param box (`ParamSet`)
     #' @param x_interest (`data.table(1)` | `data.frame(1)`) \cr
     #'   A single row with the observation of interest.

--- a/irdpackage/man/RegDesc.Rd
+++ b/irdpackage/man/RegDesc.Rd
@@ -3,13 +3,13 @@
 \name{RegDesc}
 \alias{RegDesc}
 \title{Creates a new Regional Descriptor (`RegDesc`) object.
-This method should only be called by the `$find_box` methods of \link{Prim}.}
+This method should only be called by the `$find_box` methods of regional descriptor algorithms, such as \link{Prim}, \link{MaxBox}, \link{Maire} or \link{PostProcessing}.}
 \description{
 Creates a new Regional Descriptor (`RegDesc`) object.
-This method should only be called by the `$find_box` methods of \link{Prim}.
+This method should only be called by the `$find_box` methods of regional descriptor algorithms, such as \link{Prim}, \link{MaxBox}, \link{Maire} or \link{PostProcessing}.
 
 Creates a new Regional Descriptor (`RegDesc`) object.
-This method should only be called by the `$find_box` methods of \link{Prim}.
+This method should only be called by the `$find_box` methods of regional descriptor algorithms, such as \link{Prim}, \link{MaxBox}, \link{Maire} or \link{PostProcessing}.
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -18,10 +18,10 @@ This method should only be called by the `$find_box` methods of \link{Prim}.
 Desired prediction range associated with the regional descriptor.
 Read-only! Represents the interval used to define precision.}
 
-\item{\code{box}}{(`data.table`)\cr
+\item{\code{box}}{(`ParamSet`)\cr
 The regional descriptor for `x_interest`.}
 
-\item{\code{box_single}}{(`data.table`)\cr
+\item{\code{box_single}}{(`ParamSet`)\cr
 The regional descriptors only mutating a single feature for `x_interest`.}
 
 \item{\code{x_interest}}{(`data.table(1)`) \cr

--- a/irdpackage/man/RegDesc.Rd
+++ b/irdpackage/man/RegDesc.Rd
@@ -78,9 +78,10 @@ The object (created with `iml::Predictor$new()`) holding the machine learning mo
 \item{\code{x_interest}}{(`data.table(1)` | `data.frame(1)`) \cr
 A single row with the observation of interest.}
 
-\item{\code{desired_range}}{(NULL | `numeric(2)`) \cr
-The desired predicted outcome. If NULL (default), the current predicted value of `predictor` for `x_interest` is used as desired prediction.
-Alternatively, a vector with two numeric values that specify an outcome interval. This outcome interval needs to include the predicted value of `x_interest`.}
+\item{\code{desired_range}}{(`numeric(2)`) \cr
+Desired predicted outcome interval associated with the descriptor.
+This must be a length-2 numeric vector already resolved by the calling `$find_box()` method.
+This outcome interval needs to include the predicted value of `x_interest`.}
 
 \item{\code{fixed_features}}{(`character()` | NULL)
 Names of features that are kept fixed (immutable) when constructing the descriptor.}
@@ -88,7 +89,7 @@ Names of features that are kept fixed (immutable) when constructing the descript
 \item{\code{desired_class}}{(`character(1)` | NULL)
 Desired class for classification models. NULL for regression.}
 
-\item{\code{method}}{(`character(1)` | NULL)
+\item{\code{method}}{(`character(1)`)
 Name of the method used to generate the regional descriptor.}
 }
 \if{html}{\out{</div>}}


### PR DESCRIPTION
This PR fixes some small bugs and inconsistencies in `RegDesc` and aligns documentation with the current implementation.

Changes: 
* Store `fixed_features` in `RegDesc$initialize()` so the result object preserves the immutable features passed by `find_box()`
* Remove the reference to the non-existent field `private$.data` in `RegDesc$print()`
* Update the documentation of `desired_range` to reflect that `RegDesc` expects a resolved `numeric(2)` range (the resolution happens earlier in `find_box()`)
* Align the documentation of `method` with its actual usage. The field is always a scalar character set by the calling method (e.g. `RegDescMethod` subclasses)
* Replace the incorrect `predictor$data$features.names` with `predictor$data$feature.names`, which previously caused the corresponding assertions not to trigger
* Correct the documented types of `box` and `box_single`, which both return `ParamSet` objects rather than `data.table`s.
* Fix the validation of `surface` in `plot_surface()` by using a single-choice check
* Generalize the `RegDesc` documentation so it clearly applies to descriptors produced by any implemented method
* Fix the read-only error message of the `box_single` active binding