### PR TITLE
Fixes to PRIM's pasting and param validation

### DIFF
--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -29,7 +29,7 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
                           quiet = FALSE) {
       # input checks
       super$initialize(predictor, quiet)
-      checkmate::qassert(subbox_relsize, "N?(0,1]")
+      checkmate::qassert(subbox_relsize, "N?(0,1)")
       checkmate::assert_integerish(evaluation_n, lower = 0)
       checkmate::qassert(paste_alpha, "N?(0,1)")
       checkmate::assert_choice(strategy_ties, choices = c("preddist", "random"))

--- a/irdpackage/R/Prim.R
+++ b/irdpackage/R/Prim.R
@@ -26,9 +26,9 @@ Prim = R6::R6Class("Prim", inherit = RegDescMethod,
                           quiet = FALSE) {
       # input checks
       super$initialize(predictor, quiet)
-      checkmate::assert_numeric(subbox_relsize, lower = 0, upper = 1)
-      assert_character(strategy, len = 1L)
-      assert_names(strategy, subset.of = c("traindata", "sampled"))
+      checkmate::qassert(subbox_relsize, "N?(0,1)")
+      checkmate::assert_character(strategy, len = 1L)
+      checkmate::assert_choice(strategy, choices = c("traindata", "sampled"))
 
       # assign private attr
       private$subbox_relsize = subbox_relsize

--- a/irdpackage/R/Prim.R
+++ b/irdpackage/R/Prim.R
@@ -275,6 +275,7 @@ Prim = R6::R6Class("Prim", inherit = RegDescMethod,
 
         res_table = rbindlist(a)
 
+        # Stop when there are no candidates left
         if (nrow(res_table) == 0) break
 
         res_table$mode = "pasting"
@@ -285,6 +286,7 @@ Prim = R6::R6Class("Prim", inherit = RegDescMethod,
         # get best (low impurity, high coverage)
         best = res_table[order(impurity, -coverage)[1]]
 
+        # If best box is impure, then stop pasting!
         if (best$impurity > 0) {
           break
         }
@@ -297,9 +299,6 @@ Prim = R6::R6Class("Prim", inherit = RegDescMethod,
         private$i = private$i+1L
         if (!private$quiet) {
           message(paste("pasting iteration", private$i, "with pasting variable", best$var,"and impurity = ", best$impurity))
-        }
-        if (best$impurity == 0) {
-          heterogeneous = FALSE
         }
       }
 

--- a/irdpackage/R/Prim.R
+++ b/irdpackage/R/Prim.R
@@ -113,8 +113,8 @@ Prim = R6::R6Class("Prim", inherit = RegDescMethod,
             boxdata = copy(private$obsdata)[(inbox),]
 
             # get quantile
-            lower = round(boxdata[, lapply(.SD, quantile, prob = private$subbox_relsize),  .SDcols = j])[[1]]
-            upper = round(boxdata[, lapply(.SD, quantile, prob = 1-private$subbox_relsize),  .SDcols = j])[[1]]
+            lower = boxdata[, lapply(.SD, quantile, prob = private$subbox_relsize),  .SDcols = j][[1]]
+            upper = boxdata[, lapply(.SD, quantile, prob = 1-private$subbox_relsize),  .SDcols = j][[1]]
 
             selection = c("lower", "upper")
 


### PR DESCRIPTION
- Removed unused `heterogeneous = FALSE` from pasting loop (no effect on control flow)
- Enforced stricter validation for `subbox_relsize in (0,1)` and `strategy` as a single valid choice
- Removed unnecessary rounding of quantile-based bounds in peeling (prevents distortion for continuous variables; see #7)
