### PR TITLE
Experimental faster update of ParamSet (avoid full rebuild) for the update_box function

### DIFF
--- a/irdpackage/R/helpers.R
+++ b/irdpackage/R/helpers.R
@@ -40,7 +40,7 @@ make_param_set = function(dt, subset = NULL) {
   return(ps)
 }
 
-update_box = function(current_box, j, lower = NULL, upper = NULL, val = NULL, complement = TRUE) {
+update_box_old_correct = function(current_box, j, lower = NULL, upper = NULL, val = NULL, complement = TRUE) {
   # normalize j to an id -> now feature name (zB j = "age")
   ids = current_box$ids()
   if (is.numeric(j)) {
@@ -96,6 +96,60 @@ update_box = function(current_box, j, lower = NULL, upper = NULL, val = NULL, co
   new_box$extra_trafo = current_box$extra_trafo
 
   return(new_box)
+}
+
+update_box = function(current_box, j, lower = NULL, upper = NULL, val = NULL, complement = TRUE) {
+  ids = current_box$ids()
+  if (is.numeric(j)) {
+    j = ids[[as.integer(j)]]
+  }
+
+  box = current_box$clone(deep = TRUE)
+
+  # force an actual copy of the internal params table
+  box$.__enclos_env__$private$.params = data.table::copy(
+    box$.__enclos_env__$private$.params
+  )
+
+  cls = box$class[[j]]
+
+  params_dt = box$.__enclos_env__$private$.params
+  i = which(params_dt$id == j)
+
+  if (cls %in% c("ParamInt", "ParamDbl")) {
+
+    lb = if (!is.null(lower) && !is.na(lower)) lower else current_box$lower[[j]]
+    ub = if (!is.null(upper) && !is.na(upper)) upper else current_box$upper[[j]]
+
+    if (cls == "ParamInt") {
+      if (lb != round(lb) || ub != round(ub)) {
+        stop(sprintf(
+          "Invalid bounds for integer parameter '%s': lower = %s, upper = %s. Both must be integers.",
+          j, lb, ub
+        ))
+      }
+    }
+
+    if (lb > ub) {
+      stop(sprintf(
+        "Invalid bounds for parameter '%s': lower (%s) must be <= upper (%s).",
+        j, lb, ub
+      ))
+    }
+
+    data.table::set(params_dt, i = i, j = "lower", value = lb)
+    data.table::set(params_dt, i = i, j = "upper", value = ub)
+  }
+
+  if (cls == "ParamFct") {
+    if (all(!is.null(val)) && all(!is.na(val))) {
+      lev = val
+      if (complement) lev = unique(c(current_box$levels[[j]], val))
+      data.table::set(params_dt, i = i, j = "levels", value = list(lev))
+    }
+  }
+
+  return(box)
 }
 
 evaluate_box = function(box, x_interest, predictor, n_samples, desired_range, strategy = "random") {


### PR DESCRIPTION
This PR refactors how boxes are updated in the code, that is, the function `update_box()`. 

- The previous implementation has been renamed to `update_box_old_correct()`. This version used to rebuild a new `ParamSet` each time, following the recommended approach in `paradox >= 1.0.0`, as levels and bounds should be considered immutable. This version is left there for reference. 
- A new `update_box()` is introduced, which updates bounds and levels by directly modifying the internal `.params` table

Why was this necessary? rebuilding a full `ParamSet` in every iteration (for example in PRIM or PostProcessing) is more expensive than modifying in-place -> as a consequence, running PRIM, for example, was about three times slower than with paradox 0.11.0 (which allowed direct change of bounds and levels). 

How was this solved? the new `update_box()`

- clones the input box
- explicitly copies `.params` (which avoids shared-state bugs, bc otherwise changes will also be reflected on `current_box`)
- then applies in-place updates -> either a bound is changed or a level is added/removed

What were the results?

- Both versions (`update_box_old_correct()` and the new `update_box()`) produce the same results.
- Runtime is significantly improved: roughly **~30% faster** compared to the rebuild approach.
- Performance is now comparable to (and slightly better than) the old package version using `paradox 0.11.0`. Postprocessing is even faster than before due to fewer calls to $$\hat{f}$$ from the improved integer handling introduced in the   [previous PR](https://github.com/nathaly-vergel/ird-rpackage/pull/9)

WARNING!!!
This approach relies on internal structures of `paradox` and is not officially supported, so it should be considered experimental and used with caution -> the idea comes from Marc Becker, developer of the paradox package, and he said that we should really be careful with this. 