### PR TITLE
Small fixes: methods cleanup + improved docs + anchors error handling

### DIFF
--- a/irdpackage/R/Anchor.R
+++ b/irdpackage/R/Anchor.R
@@ -26,6 +26,10 @@ Anchor = R6::R6Class("Anchor", inherit = RegDescMethod,
     #' Immutable features defined in `fixed_features` are automatially set to integer().
     #' @param ... \cr Further hyperparameters of anchors (see `anchors::anchors`).
     #' @return (RegDesc) Hyperbox
+    #' @details
+    #' This method relies on the external `anchors` backend, which is stochastic and
+    #' may fail for some random states. If this happens, rerun the method or try a
+    #' different seed before calling `$find_box()`.
     initialize = function(predictor,
                           tau = 1,
                           initialize_bins = TRUE,
@@ -135,11 +139,11 @@ Anchor = R6::R6Class("Anchor", inherit = RegDescMethod,
       if (private$quiet) {
         explanations = try({
           suppressMessages(anchors::explain(private$x_interest, explainer, labels = 1))
-        })
+        }, silent = TRUE)
       } else {
         explanations = try({
           anchors::explain(private$x_interest, explainer)
-        })
+        }, silent = TRUE)
       }
       # if (private$tries_if_error > 0) {
       #   i = 1
@@ -152,9 +156,17 @@ Anchor = R6::R6Class("Anchor", inherit = RegDescMethod,
       #   }
       # }
       if (inherits(explanations, "try-error")) {
-        message(explanations)
         closeAllConnections()
-        stop(explanations)
+
+        stop(
+          "The Anchor method failed while calling `anchors::explain()`. ",
+          "This can happen because the external anchors backend is stochastic ",
+          "and may fail for some random states. ",
+          "Please try running the method again, or set a different seed before calling `$find_box()`.\n\n",
+          "Original error:\n",
+          conditionMessage(attr(explanations, "condition")),
+          call. = FALSE
+        )
       }
 
       # postprocess output

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -180,9 +180,16 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
             if (s_j == 0) {
               rng = ps$upper[[1]] - ps$lower[[1]]
               warning(sprintf(
-                "subbox_relsize too small for integer feature '%s' (range = %s). Using step size 1 instead, equivalent to subbox_relsize = %g.",
+                paste0(
+                  "subbox_relsize too small for integer feature '%s' (range = %s). ",
+                  "Using step size 1 for this feature only (equivalent to subbox_relsize = %g). ",
+                  "The original subbox_relsize is kept unchanged for all other features."
+                ),
                 j, rng, 1 / rng
               ), call. = FALSE)
+
+              # adjust step size locally for this feature only
+              # does not modify global subbox_relsize!
               s_j = 1 # sensitivity of integers
             }
           }

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -40,9 +40,13 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
     #'   Default is `0.05`.
     #' @param evaluation_n (`numeric(1)`) \cr
     #'   Number of newly sampled points used to evaluate each candidate box or
-    #'   subbox.
+    #'   subbox during peeling and pasting.
     #'   Larger values give more stable estimates of impurity and prediction
     #'   distance but increase computation time.
+    #'
+    #'   For the initial homogeneity check of the starting box, a larger sample
+    #'   is used internally, namely `evaluation_n * p`, where `p` is the number
+    #'   of (non-fixed) features.
     #' @param paste_alpha (`numeric(1)`) \cr
     #'   Minimum relative step size allowed during the pasting phase.
     #'   If no homogeneous expansion can be found, the current pasting step size
@@ -150,7 +154,11 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
       vars_diff = setdiff(private$predictor$data$feature.names,
                           private$fixed_features)
 
-      sampled = SamplerUnif$new(box_new)$sample(n = private$evaluation_n * 5)$data
+
+      # use No of features to scale sampling (COD)
+      p = length(vars_diff)
+
+      sampled = SamplerUnif$new(box_new)$sample(n = private$evaluation_n * p)$data
       sampled = box_new$extra_trafo(x = sampled, predictor = private$predictor)
 
       private$.calls_fhat = private$.calls_fhat + nrow(sampled)

--- a/irdpackage/R/RegDescMethod.R
+++ b/irdpackage/R/RegDescMethod.R
@@ -144,7 +144,6 @@ RegDescMethod = R6::R6Class("RegDescMethod",
       private$box_largest = box_largest
       private$box_init = box_init
       box = private$run()
-      box = private$sanitize_box(box)
 
       RegDesc$new(box = box, predictor = private$predictor,
         x_interest = x_interest, desired_range = desired_range,
@@ -283,26 +282,6 @@ RegDescMethod = R6::R6Class("RegDescMethod",
       }
 
       desired_range
-    },
-    sanitize_box = function(box) {
-
-      domains = box$domains
-      ids = box$ids()
-
-      for (j in ids) {
-        if (box$class[[j]] == "ParamInt") {
-          dom = domains[[j]]
-          domains[[j]] = paradox::p_int(
-            lower = ceiling(dom$lower),
-            upper = floor(dom$upper)
-          )
-        }
-      }
-
-      new_box = paradox::ParamSet$new(params = domains)
-      new_box$extra_trafo = box$extra_trafo
-
-      return(new_box)
     },
     run = function() {
       stop("Abstract base class")

--- a/irdpackage/inst/examples/credit_example.R
+++ b/irdpackage/inst/examples/credit_example.R
@@ -165,6 +165,7 @@ maxbox_post$plot_surface(
 #                       Compute IRD with Maire
 # ------------------------------------------------------------------------
 
+set.seed(12005L)
 system.time({
   maire_res = find_ird(
     predictor = pred,
@@ -215,6 +216,7 @@ maire_post$plot_surface(
 
 anch = Anchor$new(predictor = pred)
 
+set.seed(12345L)
 system.time({
   anchor_res = anch$find_box(
     x_interest = x_interest,


### PR DESCRIPTION
* removed `sanitize_box()` since it's no longer needed: integer bounds are now handled correctly during PostProcessing itself
* improved sampling when checking homogeneity by scaling with number of features (p) instead of a fixed value → behaves better in higher dimensions
* clarified `subbox_relsize` behavior for integer features (local adjustment only, global value unchanged) and improved the warning message
* made Anchors more robust by catching failures from `anchors::explain()` and showing a clearer error suggesting to rerun or try a different seed
* added a working seed (`12345`) for the example so it runs out of the box

