### PR TITLE
Fixed print_parameters and removed duplicated code

### DIFF
--- a/irdpackage/R/Maire.R
+++ b/irdpackage/R/Maire.R
@@ -604,9 +604,25 @@ Maire = R6::R6Class("Maire",
       return(private$step_function(tf$reduce_mean(x, 1L) - private$ch))
     },
     print_parameters = function() {
-      # cat(" - searchgrid_resolution: ", private$searchgrid_resolution, "\n")
-      # cat(" - evaluation_n: ", private$evaluation_n, "\n")
-      # cat(" - paste_alpha: ", private$paste_alpha, "\n")
+      params = private$.get_parameters()
+
+      if (length(params) == 0L) {
+        cat(" - none\n")
+        return(invisible(self))
+      }
+
+      for (nm in names(params)) {
+        value = params[[nm]]
+
+        if (is.null(value)) {
+          value = "NULL"
+        } else if (length(value) > 1L) {
+          value = paste(value, collapse = ", ")
+        }
+        cat(" - ", nm, ": ", value, "\n", sep = "")
+      }
+
+      invisible(self)
     },
     .get_parameters = function() {
       list(

--- a/irdpackage/R/MaxBox.R
+++ b/irdpackage/R/MaxBox.R
@@ -401,9 +401,25 @@ MaxBox = R6::R6Class("MaxBox", inherit = RegDescMethod,
       return(current_box)
     },
     print_parameters = function() {
-      # cat(" - searchgrid_resolution: ", private$searchgrid_resolution, "\n")
-      # cat(" - evaluation_n: ", private$evaluation_n, "\n")
-      # cat(" - paste_alpha: ", private$paste_alpha, "\n")
+      params = private$.get_parameters()
+
+      if (length(params) == 0L) {
+        cat(" - none\n")
+        return(invisible(self))
+      }
+
+      for (nm in names(params)) {
+        value = params[[nm]]
+
+        if (is.null(value)) {
+          value = "NULL"
+        } else if (length(value) > 1L) {
+          value = paste(value, collapse = ", ")
+        }
+        cat(" - ", nm, ": ", value, "\n", sep = "")
+      }
+
+      invisible(self)
     },
     .get_parameters = function() {
       list(


### PR DESCRIPTION
Removed the copy-pasted print_parameters from MaxBox and Maire and moved to a single generic implementation in RegDescMethod. Now printing always relies on .get_parameters(), so it stays consistent automatically