### PR TITLE
Unify printing for RegDescMethod (removed print_parameters)

### DIFF
--- a/irdpackage/R/Anchor.R
+++ b/irdpackage/R/Anchor.R
@@ -218,11 +218,6 @@ Anchor = R6::R6Class("Anchor", inherit = RegDescMethod,
       }
       return(current_box)
     },
-    print_parameters = function() {
-      # cat(" - searchgrid_resolution: ", private$searchgrid_resolution, "\n")
-      # cat(" - evaluation_n: ", private$evaluation_n, "\n")
-      # cat(" - paste_alpha: ", private$paste_alpha, "\n")
-    },
     .get_parameters = function() {
       list(
         tau = private$tau,

--- a/irdpackage/R/Maire.R
+++ b/irdpackage/R/Maire.R
@@ -603,27 +603,6 @@ Maire = R6::R6Class("Maire",
     A = function(x) {
       return(private$step_function(tf$reduce_mean(x, 1L) - private$ch))
     },
-    print_parameters = function() {
-      params = private$.get_parameters()
-
-      if (length(params) == 0L) {
-        cat(" - none\n")
-        return(invisible(self))
-      }
-
-      for (nm in names(params)) {
-        value = params[[nm]]
-
-        if (is.null(value)) {
-          value = "NULL"
-        } else if (length(value) > 1L) {
-          value = paste(value, collapse = ", ")
-        }
-        cat(" - ", nm, ": ", value, "\n", sep = "")
-      }
-
-      invisible(self)
-    },
     .get_parameters = function() {
       list(
         num_of_iterations = private$num_of_iterations,

--- a/irdpackage/R/MaxBox.R
+++ b/irdpackage/R/MaxBox.R
@@ -407,27 +407,6 @@ MaxBox = R6::R6Class("MaxBox", inherit = RegDescMethod,
       }
       return(current_box)
     },
-    print_parameters = function() {
-      params = private$.get_parameters()
-
-      if (length(params) == 0L) {
-        cat(" - none\n")
-        return(invisible(self))
-      }
-
-      for (nm in names(params)) {
-        value = params[[nm]]
-
-        if (is.null(value)) {
-          value = "NULL"
-        } else if (length(value) > 1L) {
-          value = paste(value, collapse = ", ")
-        }
-        cat(" - ", nm, ": ", value, "\n", sep = "")
-      }
-
-      invisible(self)
-    },
     .get_parameters = function() {
       list(
         strategy = private$strategy,

--- a/irdpackage/R/PostProcessing.R
+++ b/irdpackage/R/PostProcessing.R
@@ -645,11 +645,6 @@ PostProcessing = R6::R6Class("PostProcessing", inherit = RegDescMethod,
       private$searchspace[[var]] = s[lapply(s, length) > 0]
       private$searchspace = private$searchspace[lapply(private$searchspace, length) > 0]
     },
-    print_parameters = function() {
-      cat(" - subbox_relsize: ", private$subbox_relsize, "\n")
-      cat(" - evaluation_n: ", private$evaluation_n, "\n")
-      cat(" - paste_alpha: ", private$paste_alpha, "\n")
-    },
     .get_parameters = function() {
       list(
         subbox_relsize = private$subbox_relsize,

--- a/irdpackage/R/Prim.R
+++ b/irdpackage/R/Prim.R
@@ -393,9 +393,6 @@ Prim = R6::R6Class("Prim", inherit = RegDescMethod,
       searchspace = searchspace[lapply(searchspace, length) > 0]
       return(searchspace)
     },
-    print_parameters = function() {
-      cat(" - subbox_relsize: ", private$subbox_relsize, "\n")
-    },
     .get_parameters = function() {
       list(
         subbox_relsize = private$subbox_relsize

--- a/irdpackage/R/RegDescMethod.R
+++ b/irdpackage/R/RegDescMethod.R
@@ -34,12 +34,12 @@ RegDescMethod = R6::R6Class("RegDescMethod",
 
     #' @description
     #' Prints a `RegDescMethod` object.
-    #' The method calls a (private) `$print_parameters()` method which should be
-    #' implemented by the leaf classes.
+    #' The method prints the named list returned by `$get_parameters()`.
     print = function() {
       cat("Regional descriptor method: ", class(self)[1], "\n")
       cat("Parameters:\n")
-      private$print_parameters()
+      private$print_parameters(private$.get_parameters())
+      invisible(self)
     },
     #' @description
     #' Returns the method hyperparameters as a named list.
@@ -289,6 +289,28 @@ RegDescMethod = R6::R6Class("RegDescMethod",
     .get_parameters = function() {
       list()
     },
-    print_parameters = function() {}
+    print_parameters = function(params) {
+      if (length(params) == 0L) {
+        cat(" - none\n")
+        return(invisible(self))
+      }
+
+      for (nm in names(params)) {
+        cat(" - ", nm, ": ", private$format_parameter(params[[nm]]), "\n", sep = "")
+      }
+
+      invisible(self)
+    },
+    format_parameter = function(value) {
+      if (is.null(value)) {
+        return("NULL")
+      }
+
+      if (length(value) > 1L) {
+        return(paste(value, collapse = ", "))
+      }
+
+      as.character(value)
+    }
   )
 )

--- a/irdpackage/R/RegDescMethod.R
+++ b/irdpackage/R/RegDescMethod.R
@@ -36,9 +36,10 @@ RegDescMethod = R6::R6Class("RegDescMethod",
     #' Prints a `RegDescMethod` object.
     #' The method prints the named list returned by `$get_parameters()`.
     print = function() {
-      cat("Regional descriptor method: ", class(self)[1], "\n")
+      cat("Regional descriptor method: ", class(self)[1], "\n", sep = "")
       cat("Parameters:\n")
-      private$print_parameters(private$.get_parameters())
+      cat(private$format_parameters(private$.get_parameters()), sep = "\n")
+      cat("\n")
       invisible(self)
     },
     #' @description
@@ -289,17 +290,14 @@ RegDescMethod = R6::R6Class("RegDescMethod",
     .get_parameters = function() {
       list()
     },
-    print_parameters = function(params) {
+    format_parameters = function(params) {
       if (length(params) == 0L) {
-        cat(" - none\n")
-        return(invisible(self))
+        return(" - none")
       }
 
-      for (nm in names(params)) {
-        cat(" - ", nm, ": ", private$format_parameter(params[[nm]]), "\n", sep = "")
-      }
-
-      invisible(self)
+      vapply(names(params), function(nm) {
+        paste0(" - ", nm, ": ", private$format_parameter(params[[nm]]))
+      }, character(1))
     },
     format_parameter = function(value) {
       if (is.null(value)) {


### PR DESCRIPTION
Removed the duplicated `print_parameters()` implementations from `RegDescMethod` child classes, since .get_parameters was introduced

- `RegDescMethod$print()` now formats the output from `private$.get_parameters()`
- Child classes only need to define `.get_parameters()` as the single source of truth for method parameters
- Removed all `print_parameters()` methods from subclasses

NOTE: Having access to a named list is, imo, a lot more useful for the user than a print. 